### PR TITLE
Want to pin all the currently used requirements/extras to specific versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -228,6 +228,7 @@ Query a SQLite table using a query file and write the results to a CSV with NULL
 
 Changelog
 ---------
+- 0.4.8: Pinning requirement and "extras" requirements to specific versions where applicable 
 - 0.4.7: When a new staging table is created with the postgres db, grants are copied over as well
 - 0.4.6: Making version number read from all dbio/__init__.py so it doesn't need to copied and pasted everywhere.
 - 0.4.5: Explicit SQLAlchemy transaction creation.

--- a/dbio/__init__.py
+++ b/dbio/__init__.py
@@ -1,4 +1,4 @@
 from io import load, query, replicate, replicate_no_fifo
 
 __all__ = ['io', 'databases']
-__version__ = '0.4.7'
+__version__ = '0.4.8'

--- a/setup.py
+++ b/setup.py
@@ -58,14 +58,14 @@ setup(
         ]
     },
     install_requires=[
-        'sqlalchemy',
-        'unicodecsv'
+        'sqlalchemy==1.0.8',
+        'unicodecsv==0.14.1'
     ],
     extras_require={
-        'MySQL': ['MySQL-python'],
-        'Vertica': ['vertica-python', 'sqlalchemy-vertica-python'],
+        'MySQL': ['MySQL-python==1.2.3'],
+        'Vertica': ['vertica-python==0.5.1', 'sqlalchemy-vertica-python==0.1.2'],
         'VerticaODBC': ['pyodbc', 'vertica-sqlalchemy'],
-        'PostgreSQL': ['psycopg2'],
+        'PostgreSQL': ['psycopg2==2.4.5'],
     },
     tests_require=[
         'pytest',


### PR DESCRIPTION
Pinning everything except for VerticaODBC since its not being used and therefore not tied to anything right now.
