### PR TITLE
Adding Support for Vertical DIRECT keyword for COPY

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,7 @@ Optional flags:
 -  ``-nf``: does not use ``mkfifo()``. Use this if ``mkfifo()`` is not available.
 -  ``-s``: expects an table named 'table_staging' to already exist.
 -  ``-rc``: performs a check to ensure that the query rowcount matches the load table rowcount.
+-  ``-dt``: Adds direct keyword to Vertica copy commands used in loading data.
    supported by your OS (e.g. Windows).
 
 How it Works
@@ -122,6 +123,7 @@ Optional flags:
 -  ``-i``: drops or disable indices while loading, recreating them afterwards.
 -  ``-s``: expects a table named 'table_staging' to already exist.
 -  ``-rc``: the number of rows to ensure are present in the table after loading.
+-  ``-dt``: Adds direct keyword to Vertica copy commands used in loading data.
 - csv flags:
     * ``-qc``: character to enclose fields. If not included, fields are not enclosed.
     * ``-ns``: string to replace NULL fields. Defaults to "NULL".
@@ -228,6 +230,7 @@ Query a SQLite table using a query file and write the results to a CSV with NULL
 
 Changelog
 ---------
+- 0.5.0: Adding in ability to add Vertica DIRECT hint when loading data into Vertica
 - 0.4.9: Deleting staging table prior to creating it to ensure that function does not fail for that reason.
 - 0.4.8: Pinning requirement and "extras" requirements to specific versions where applicable 
 - 0.4.7: When a new staging table is created with the postgres db, grants are copied over as well

--- a/dbio/__init__.py
+++ b/dbio/__init__.py
@@ -1,4 +1,4 @@
 from io import load, query, replicate, replicate_no_fifo
 
 __all__ = ['io', 'databases']
-__version__ = '0.4.9'
+__version__ = '0.5.0'

--- a/dbio/__main__.py
+++ b/dbio/__main__.py
@@ -13,7 +13,7 @@ def load(args):
 	io.load(args.db_url, args.table, args.filename, args.append, analyze=args.analyze,
 			disable_indices=args.disable_indices, csv_params=csv_params,  
 			null_string=args.null_string, create_staging=args.create_staging, 
-			expected_rowcount=args.expected_rowcount)
+			expected_rowcount=args.expected_rowcount, direct=args.direct)
 
 
 def query(args):
@@ -27,13 +27,13 @@ def replicate(args):
 		io.replicate(args.query_db_url, args.load_db_url, args.query, args.table, 
 					 args.append, analyze=args.analyze, disable_indices=args.disable_indices,
 					 query_is_file=args.from_file, create_staging=args.create_staging,
-					 do_rowcount_check=args.rowcount_check)
+					 do_rowcount_check=args.rowcount_check, direct=args.direct)
 	else:
 		io.replicate_no_fifo(args.query_db_url, args.load_db_url, args.query, args.table, 
 							 args.append, analyze=args.analyze, 
 							 disable_indices=args.disable_indices,
 							 query_is_file=args.from_file, create_staging=args.create_staging,
-							 do_rowcount_check=args.rowcount_check)
+							 do_rowcount_check=args.rowcount_check, direct=args.direct)
 
 
 def main():
@@ -92,6 +92,8 @@ def __setup_replicate_parser(subparsers):
 									help="Include if a table named table_staging already exists.")
 	replicate_parser.add_argument('-rc', '--rowcount-check', dest='rowcount_check', action='store_true',
 									help="Only succeed if the load table rowcount matches the query rowcount.")
+	replicate_parser.add_argument('-dt', '--direct', dest='direct', action='store_const', const='DIRECT',
+								  default='', help="Special keywoard for Vertica load commands to skip WOS")
 	replicate_parser.set_defaults(func=replicate)
 
 
@@ -136,6 +138,8 @@ def __setup_load_parser(subparsers):
 									help="Include if a table named table_staging already exists.")
 	load_parser.add_argument('-r', '--expected-rowcount', dest='expected_rowcount', type=int,
 									help='Number of rows expected in the table after loading.')
+	load_parser.add_argument('-dt', '--direct', dest='direct', action='store_const', const='DIRECT',
+							 default='', help="Special keywoard for Vertica load commands to skip WOS")
 	# CSV ARGS
 	load_parser.add_argument('-qc', '--quotechar', default=None, help='Character to enclose fields. If not included, fields are not enclosed.')
 	load_parser.add_argument('-ns', '--null-string', default=DEFAULT_NULL_STRING, help='String to replace NULL fields.')

--- a/dbio/databases/base.py
+++ b/dbio/databases/base.py
@@ -91,7 +91,7 @@ class Importable():
 
 	def execute_import(self, table, filename, append, csv_params, null_string, 
 						analyze=False, disable_indices=False, create_staging=True,
-						expected_rowcount=None):
+						expected_rowcount=None, **kwargs):
 		""" Database specific implementation of loading from a CSV
 
 			:param table: destination for the load operation.

--- a/dbio/databases/mysql.py
+++ b/dbio/databases/mysql.py
@@ -72,7 +72,7 @@ class MySQL(Exportable, Importable):
 
 	def execute_import(self, table, filename, append, csv_params, null_string, 
 						analyze=False, disable_indices=False, create_staging=True,
-						expected_rowcount=None):
+						expected_rowcount=None, **kwargs):
 		staging = table + '_staging'
 		temp = table + '_temp'
 		if append:

--- a/dbio/databases/postgresql.py
+++ b/dbio/databases/postgresql.py
@@ -53,7 +53,7 @@ class PostgreSQL(Exportable, Importable):
 
     def execute_import(self, table, filename, append, csv_params, null_string,
                        analyze=False, disable_indices=False, create_staging=True,
-                       expected_rowcount=None):
+                       expected_rowcount=None, **kwargs):
         staging = table + '_staging'
         temp = table + '_temp'
         if append:

--- a/dbio/databases/sqlite.py
+++ b/dbio/databases/sqlite.py
@@ -36,7 +36,7 @@ class SQLite(Exportable, Importable):
 
 	def execute_import(self, table, filename, append, csv_params, null_string, 
 						analyze=False, disable_indices=False, create_staging=True,
-						expected_rowcount=None):
+						expected_rowcount=None, **kwargs):
 		staging = table + '_staging'
 		temp = table + '_temp'
 		if append:


### PR DESCRIPTION
1. Added command line support for direct keyword
2. Modified all the DB classes to accept kwargs so 
   they ignore the direct keyword even if its passed 
   in. Also was able to get rid of unnecessary arg for 
   Vertica
3. Added in support for direct in load & replicate
4. Update README & version to reflect new changes
